### PR TITLE
Bug fixing environment variable translation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 LeanKit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,60 @@
 # configya
 Stupid simple configuration.
 
-##What & How
-`configya` reads your environment variables as well as an optional configuration file (you provide the path, in that case), and returns a configuration object to you.
+## What & How
+`configya` reads the following:
+ * environment variables
+ * optional configuration 
+ * defaults hash
 
-###Environment Variables
-`configya` will parse your environment variables into an object hierarchy if you use underscores to delimit them. For example, if you have an environment variable called `RABBIT_BROKER_IP` set to "127.0.0.1", and another one called `RABBIT_BROKER_PORT` (set to 5672), they will be parsed to this representation:
+**Note**: it is impossible to have both a configuration file and a defaults hash. Pick one.
 
+Unless you've set a `deploy-type` environment variable = 'DEV', `configya` will always overwrite keys from a configuration file or defaults hash with duplicates found in the environment.
 
-	{
-		rabbit: {
-			broker: {
-				ip: "127.0.0.1",
-				port: "5672"
-			}
+### Key Parsing
+`configya` parses all sources into an object hierarchy based on `_` delimited key names. For example, if you have a key named `RABBIT_BROKER_IP` set to '127.0.0.1', and another named `RABBIT_BROKER_PORT` set to 5672, the resulting configuration object will be:
+
+```javascript
+{
+	rabbit: {
+		broker: {
+			ip: "127.0.0.1",
+			port: "5672"
 		}
 	}
+}
+```
+**Note**: All keys are lower-cased to eliminate the need for guessing games (and capslock)
 
 
-Notice that the environment variables are transformed to lower case as well.
+### Original Keys
+The original keys are technically still stored on the object based on their source.
+ * \__env__ for original environment keys
+ * \__defaults__ for keys coming from a defaults hash
+ * \__file__ for keys coming from a file
 
-By default, configya will prefer to use your environment variables. If you provide a config file as well, it will still prefer environment variables unless you add this to your environment variables: `deploy-type=DEV`. With `deploy-type` set to DEV, `configya` will use values from your config file, *if they exist*, before an environment variable.
+**Note**: These are really here for diagnostic/backwards compatibility. You shouldn't use/rely on them in your code.
  
 ## Usage
 
+```javascript
 	//load configya without a config file (using only environment)
 	var cfg = require('configya')();
 
-	//load configta with a config file as well
+	//load configya with a config file as well
 	var cfg = require('configya')('./path/to/configuration.json');
 
+	//load configya with a defaults hash
+	var cfg = require('configya')( { RABBIT_BROKER_PORT: 5672 } );
+
 	var port = cfg.rabbit.broker.port; // etc.
-
-
-For the oddball edge case(s), the environment variables are also available on `configya` in an un-transformed state:
-
-
-	// This isn't how you want to get at your config data....
-	var port = cfg.__env__.RABBIT_BROKER_PORT;
-
+```
 
 ## Backwards Compatibility
 
-The original version of `configya` (v0.0.3) used a `get` method to retrieve configuration values. This is technically still supported, though we recommend using the approach described above. Here's a usage example based on the older API:
+The original version of `configya` used a `get` method to retrieve configuration values with the ability to specify a default/fallback if the key were missing. This is technically still supported, but we think the new approach (nested keys) is nicer. Here's an example of the original API:
 
-
+```javascript
 	var config = require( 'configya' )( './path/config.json' );
 
 	// get the value from the config file, if an 
@@ -54,4 +64,4 @@ The original version of `configya` (v0.0.3) used a `get` method to retrieve conf
 	config.get( 'key' );
 
 	config.get( 'key', defaultValue );
-
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configya",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Config files that defer to env settings.",
   "main": "src/configya.js",
   "scripts": {
@@ -9,7 +9,7 @@
   "author": "LeanKit",
   "license": "MIT License - http://opensource.org/licenses/MIT",
   "devDependencies": {
-    "gulp": "~3.5.6",
+    "gulp": "^3.8.6",
     "gulp-mocha": "~0.4.1",
     "should": "~3.2.0-beta1"
   },

--- a/spec/config.spec.js
+++ b/spec/config.spec.js
@@ -173,6 +173,39 @@ describe( 'when accessing configuration data directly (new API)', function() {
 		} );
 
 	} );
+
+	describe( 'with nested file key', function() {
+		var cfg;
+
+		before( function() {
+			cfg = require( '../src/configya.js' )( './spec/test.json' );
+		} );
+
+		it( 'should contain original key', function() {
+			cfg[ 'NESTED_KEY' ].should.equal( 'a test of nested keys from files' );
+		} );
+
+		it( 'should contain nested key format', function() {
+			cfg.nested.key.should.equal( 'a test of nested keys from files' );
+		} );
+	} );
+
+	describe( 'with defaults literal', function() {
+		var cfg;
+
+		before( function() {
+			cfg = require( '../src/configya.js' )( { 'missing_from_config': 'override-me', 'default_key': 'ohhai' } );
+		} );
+
+		it( 'should override default key from env', function() {
+			cfg.missing.from.config.should.equal( 'env' );
+		} );
+
+		it( 'should supply default for missing key', function() {
+			cfg.default.key.should.equal( 'ohhai' );
+		} );
+	} );
+
 	after( function() {
 		delete process.env[ 'missing_from_config' ];
 		delete process.env[ 'deploy-type' ];

--- a/spec/test.json
+++ b/spec/test.json
@@ -1,4 +1,5 @@
 {
 	"test-key": "hulloo",
-	"override-me": "you will see this only when you have deploy-type set to 'DEV'"
+	"override-me": "you will see this only when you have deploy-type set to 'DEV'",
+	"NESTED_KEY": "a test of nested keys from files"
 }

--- a/src/configya.js
+++ b/src/configya.js
@@ -15,15 +15,19 @@ function ensurePath( target, val, paths ) {
 	}
 }
 
-function parseEnvVarsIntoConfig( config ) {
+function parseIntoTarget( source, target, original ) {
 	var undRegx = /^[_]+/;
-	gnosis.traverse( process.env, function( instance, key, val, meta, root ) {
+	gnosis.traverse( source, function( instance, key, val, meta, root ) {
 		var k = key.toLowerCase();
-		config.__env__[ key ] = val;
-		config[ key ] = val;
+		target[ k ] = val;
+		target[ key ] = val;
+		if( original ) {
+			target[ original ][ key ] = val;
+		}
 		var paths = undRegx.test( key ) ? [ k ] : k.split( "_" );
-		ensurePath( config, val, paths );
+		ensurePath( target, val, paths );
 	} );
+	return target;
 }
 
 function parseFileIntoConfig( config, pathToCfg, options ) {
@@ -32,10 +36,12 @@ function parseFileIntoConfig( config, pathToCfg, options ) {
 		try {
 			var raw = fs.readFileSync( fullPath );
 			var json = JSON.parse( raw );
+			var file = { __file__: {} };
+			parseIntoTarget( json, file, '__file__' );
 			if ( options.preferCfgFile ) {
-				_.merge( config, json );
+				_.merge( config, file );
 			} else {
-				_.defaults( config, json );
+				_.defaults( config, file );
 			}
 		} catch ( err ) {
 			console.log( 'error parsing configuration at "', fullPath, '"', err );
@@ -43,7 +49,7 @@ function parseFileIntoConfig( config, pathToCfg, options ) {
 	}
 }
 
-module.exports = function( configFile ) {
+module.exports = function( option ) {
 	var preferCfgFile = process.env[ 'deploy-type' ] === 'DEV';
 	var config = {
 		__env__: {},
@@ -57,12 +63,16 @@ module.exports = function( configFile ) {
 		}
 	};
 
-	parseEnvVarsIntoConfig( config );
+	parseIntoTarget( process.env, config, '__env__' );
 
-	if ( configFile ) {
-		parseFileIntoConfig( config, configFile, {
+	if ( _.isString( option ) ) {
+		parseFileIntoConfig( config, option, {
 			preferCfgFile: preferCfgFile
 		} );
+	} else if( option ) {
+		var defaults = { __defaults__: {} };
+		parseIntoTarget( option, defaults, '__defaults__' );
+		_.defaults( config, defaults );
 	}
 
 	return config;


### PR DESCRIPTION
The following 2 use cases were broken. This PR corrects both:

**If an environment variable would result in more than 2 levels of nesting**
_Example_: Given an environment variable named `THIS_IS_AWESOME`, configya would throw type errors due to a defect in how traversal was being handled.

**If a user attempt to access an environment variable using it's original name as a key**
_Example_: Given an environment variable named `BACON_FLAVOR`, configya would not have a property named `BACON_FLAVOR` - breaking a unit test that specified this should be an allowed pattern.
