### PR TITLE
Added support for camelCase keys, change nested separator to __

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stupid simple configuration.
 Unless you've set a `deploy-type` environment variable = 'DEV', `configya` will always overwrite keys from a configuration file and defaults hash with duplicates found in the environment.
 
 ### Key Parsing
-`configya` parses all sources into an object hierarchy based on `_` delimited key names. For example, if you have a key named `RABBIT_BROKER_IP` set to '127.0.0.1', and another named `RABBIT_BROKER_PORT` set to 5672, the resulting configuration object will be:
+`configya` parses all sources into an object hierarchy based on `__` delimited key names. For example, if you have a key named `RABBIT__BROKER__IP` set to '127.0.0.1', and another named `RABBIT__BROKER__PORT` set to 5672, the resulting configuration object will be:
 
 ```javascript
 {
@@ -24,10 +24,21 @@ Unless you've set a `deploy-type` environment variable = 'DEV', `configya` will 
 	}
 }
 ```
-**Note**: All keys are lower-cased to eliminate the need for guessing games (and capslock)
+**Note**: All keys are lower-cased to eliminate the need for guessing games (and capslock) with the exception of keys with `_` separating words (see below).
+
+Camel case is supported by using a single `_` underscore between words. If you have a key named `SQL__USER_NAME` (notice the single underscore `_`) set to 'siteuser', and another named `SQL__TARGET_SERVER` set to 'localhost', the resulting configuration object will be:
+
+```javascript
+{
+    sql: {
+        userName: "siteuser",
+        targetServer: "localhost"
+    }
+}
+```
 
 ### Key Prefixing
-`configya` lets you specify a prefix for your environment variables to be removed when your configuration is created. For example, if you have an environment variable `LK_RABBIT_BROKER_PORT` set to 5672, and call configya with the `prefix` option `var cfg = require( 'configya' )({prefix:'lk'});`, the resulting configuration object will be:
+`configya` lets you specify a prefix for your environment variables to be removed when your configuration is created. For example, if you have an environment variable `LK__RABBIT__BROKER__PORT` set to 5672, and call configya with the `prefix` option `var cfg = require( 'configya' )({prefix:'lk'});`, the resulting configuration object will be:
 ```javascript
 {
     rabbit: {
@@ -60,7 +71,7 @@ The original keys are technically still stored on the object based on their sour
 
 	//with a defaults hash
 	var cfg = require( 'configya' )({
-        defaults: { RABBIT_BROKER_PORT: 5672 }
+        defaults: { RABBIT__BROKER__PORT: 5672 }
     });
 
 	//with defaults and a config
@@ -84,7 +95,7 @@ The previous version of `configya` accepted multiple arguments of either a strin
      var cfg = require( 'configya' )( './path/to/configuration.json' );
 
      //with a defaults hash
-     var cfg = require( 'configya' )( { RABBIT_BROKER_PORT: 5672 } );
+     var cfg = require( 'configya' )( { RABBIT__BROKER__PORT: 5672 } );
 
      //with defaults and a config (order of args doesn't matter)
      var cfg = require( 'configya' )( { rabbit: { broker: { port: 5672 } } }, './path/to/configuration.json' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configya",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Config files that defer to env settings.",
   "main": "src/configya.js",
   "scripts": {

--- a/spec/argument-config.spec.js
+++ b/spec/argument-config.spec.js
@@ -27,13 +27,13 @@ describe( 'when configuring via arguments', function() {
 			var cfg;
 
 			before( function() {
-				process.env[ 'missing_from_config' ] = 'env';
+				process.env[ 'missing__from__config' ] = 'env';
 				process.env[ 'override-me' ] = 'OVERRIDE!';
 				cfg = require( '../src/configya.js' )( './spec/test.json' );
 			} );
 
 			after( function() {
-				delete process.env[ 'missing_from_config' ];
+				delete process.env[ 'missing__from__config' ];
 				delete process.env[ 'override-me' ];
 			} );
 
@@ -63,13 +63,13 @@ describe( 'when configuring via arguments', function() {
 
 		before( function() {
 			process.env[ 'deploy-type' ] = 'DEV';
-			process.env[ 'missing_from_config' ] = 'env';
+			process.env[ 'missing__from__config' ] = 'env';
 			cfg = require( '../src/configya.js' )( './spec/test.json' );
 		} );
 
 		after( function() {
 			delete process.env[ 'deploy-type' ];
-			delete process.env[ 'missing_from_config' ];
+			delete process.env[ 'missing__from__config' ];
 		} );
 
 		it( 'missing key should be missing', function() {
@@ -78,7 +78,7 @@ describe( 'when configuring via arguments', function() {
 		} );
 
 		it( 'environment key should return value', function() {
-			cfg[ 'missing_from_config' ]
+			cfg[ 'missing__from__config' ]
 				.should.equal( 'env' );
 		} );
 
@@ -97,7 +97,7 @@ describe( 'when configuring via arguments', function() {
 		} );
 
 		it( 'should contain original key', function() {
-			cfg[ 'NESTED_KEY' ].should.equal( 'a test of nested keys from files' );
+			cfg[ 'NESTED__KEY' ].should.equal( 'a test of nested keys from files' );
 		} );
 
 		it( 'should contain nested key format', function() {
@@ -109,12 +109,12 @@ describe( 'when configuring via arguments', function() {
 		var cfg;
 
 		before( function() {
-			process.env["missing_from_config"] = "env";
-			cfg = require( '../src/configya.js' )( { 'missing_from_config': 'override-me', 'default_key': 'ohhai' } );
+			process.env["missing__from__config"] = "env";
+			cfg = require( '../src/configya.js' )( { 'missing__from__config': 'override-me', 'default__key': 'ohhai' } );
 		} );
 
 		after( function() {
-			delete process.env["missing_from_config"];
+			delete process.env["missing__from__config"];
 		} );
 
 		it( 'should override default key from env', function() {
@@ -129,8 +129,8 @@ describe( 'when configuring via arguments', function() {
 	describe( 'with identical child trees', function() {
 		var cfg
 		before( function() {
-			process.env[ 'test_redis_port' ] = 6379;
-			process.env[ 'test_riak_port' ] = 8087;
+			process.env[ 'test__redis__port' ] = 6379;
+			process.env[ 'test__riak__port' ] = 8087;
 			cfg = require( '../src/configya.js' )(
 				{
 					test: {
@@ -141,8 +141,8 @@ describe( 'when configuring via arguments', function() {
 		} );
 
 		after( function() {
-			delete process.env[ 'test_redis_port' ];
-			delete process.env[ 'test_riak_port' ];
+			delete process.env[ 'test__redis__port' ];
+			delete process.env[ 'test__riak__port' ];
 		} );
 
 

--- a/spec/deprecated.spec.js
+++ b/spec/deprecated.spec.js
@@ -50,13 +50,13 @@ describe( 'when using deprecated API (calling get())', function() {
     var cfg;
 
     before( function() {
-      process.env[ 'missing_from_config' ] = 'env';
+      process.env[ 'missing__from__config' ] = 'env';
       process.env[ 'override-me' ] = 'OVERRIDE!';
       cfg = require( '../src/configya.js' )( './spec/test.json' );
     } );
 
     after( function() {
-      delete process.env[ 'missing_from_config' ];
+      delete process.env[ 'missing__from__config' ];
       delete process.env[ 'override-me' ];
     } );
 
@@ -72,7 +72,7 @@ describe( 'when using deprecated API (calling get())', function() {
       } );
 
       it( 'environment key should return value', function() {
-        cfg.get( 'missing_from_config' )
+        cfg.get( 'missing__from__config' )
           .should.equal( 'env' );
       } );
 
@@ -106,7 +106,7 @@ describe( 'when using deprecated API (calling get())', function() {
       } );
 
       it( 'environment key should return value', function() {
-        cfg.get( 'missing_from_config' )
+        cfg.get( 'missing__from__config' )
           .should.equal( 'env' );
       } );
 

--- a/spec/object-config.spec.js
+++ b/spec/object-config.spec.js
@@ -28,13 +28,14 @@ describe( 'when configuring via object', function() {
 		var cfg;
 
 		before( function() {
-			process.env[ 'missing_from_config' ] = 'env';
+			process.env[ 'missing__from__config' ] = 'env';
+			process.env[ 'missing__with_camel_case' ] = 'env';
 			process.env[ 'override-me' ] = 'OVERRIDE!';
 			cfg = require( '../src/configya.js' )( {file:'./spec/test.json'} );
 		} );
 
 		after( function() {
-			delete process.env[ 'missing_from_config' ];
+			delete process.env[ 'missing__from__config' ];
 			delete process.env[ 'override-me' ];
 		} );
 
@@ -46,6 +47,12 @@ describe( 'when configuring via object', function() {
 
 			it( 'environment key should return value', function() {
 				cfg.missing.from.config
+					.should.equal( 'env' );
+			} );
+
+			it( 'environment key should return value for camelCase property', function() {
+				console.log( cfg.missing );
+				cfg.missing.withCamelCase
 					.should.equal( 'env' );
 			} );
 
@@ -62,13 +69,13 @@ describe( 'when configuring via object', function() {
 
 		before( function() {
 			process.env[ 'deploy-type' ] = 'DEV';
-			process.env[ 'missing_from_config' ] = 'env';
+			process.env[ 'missing__from__config' ] = 'env';
 			cfg = require( '../src/configya.js' )( {file:'./spec/test.json'} );
 		} );
 
 		after( function() {
 			delete process.env[ 'deploy-type' ];
-			delete process.env[ 'missing_from_config' ];
+			delete process.env[ 'missing__from__config' ];
 		} );
 
 		it( 'missing key should be missing', function() {
@@ -77,7 +84,7 @@ describe( 'when configuring via object', function() {
 		} );
 
 		it( 'environment key should return value', function() {
-			cfg[ 'missing_from_config' ]
+			cfg[ 'missing__from__config' ]
 				.should.equal( 'env' );
 		} );
 
@@ -95,12 +102,14 @@ describe( 'when configuring via object', function() {
 			cfg = require( '../src/configya.js' )( {file:'./spec/test.json'} );
 		} );
 
-		it( 'should contain original key', function() {
-			cfg[ 'NESTED_KEY' ].should.equal( 'a test of nested keys from files' );
+		it( 'should contain original keys', function() {
+			cfg[ 'NESTED__KEY' ].should.equal( 'a test of nested keys from files' );
+			cfg[ 'NESTED_KEY' ].should.equal( 'a test of nested keys with camelCase syntax' );
 		} );
 
 		it( 'should contain nested key format', function() {
 			cfg.nested.key.should.equal( 'a test of nested keys from files' );
+			cfg.nestedKey.should.equal( 'a test of nested keys with camelCase syntax' );
 		} );
 	} );
 
@@ -108,17 +117,17 @@ describe( 'when configuring via object', function() {
 		var cfg;
 
 		before( function() {
-			process.env["missing_from_config"] = "env";
+			process.env["missing__from__config"] = "env";
 			cfg = require( '../src/configya.js' )( {
 				defaults:{
-					'missing_from_config': 'override-me',
-					'default_key': 'ohhai'
+					'missing__from__config': 'override-me',
+					'default__key': 'ohhai'
 				}
 			});
 		});
 
 		after( function() {
-			delete process.env["missing_from_config"];
+			delete process.env["missing__from__config"];
 		} );
 
 		it( 'should override default key from env', function() {
@@ -133,8 +142,8 @@ describe( 'when configuring via object', function() {
 	describe( 'with identical child trees', function() {
 		var cfg
 		before( function() {
-			process.env[ 'test_redis_port' ] = 6379;
-			process.env[ 'test_riak_port' ] = 8087;
+			process.env[ 'test__redis__port' ] = 6379;
+			process.env[ 'test__riak__port' ] = 8087;
 			cfg = require( '../src/configya.js' )( {
 				defaults:{
 					test: {
@@ -146,8 +155,8 @@ describe( 'when configuring via object', function() {
 		} );
 
 		after( function() {
-			delete process.env[ 'test_redis_port' ];
-			delete process.env[ 'test_riak_port' ];
+			delete process.env[ 'test__redis__port' ];
+			delete process.env[ 'test__riak__port' ];
 		} );
 
 

--- a/spec/prefix.spec.js
+++ b/spec/prefix.spec.js
@@ -20,8 +20,8 @@ describe( 'when accessing configuration data directly while providing environmen
 		var cfg;
 
 		before( function() {
-			process.env[ 'LK_MISSING_FROM_CONFIG' ] = 'lol';
-			process.env[ 'lk_override-me' ] = 'OVERRIDDEN!';
+			process.env[ 'LK__MISSING__FROM__CONFIG' ] = 'lol';
+			process.env[ 'lk__override-me' ] = 'OVERRIDDEN!';
 			cfg = require( '../src/configya.js' )({
 				file: './spec/test.json',
 				prefix: 'lk'
@@ -29,8 +29,8 @@ describe( 'when accessing configuration data directly while providing environmen
 		} );
 
 		after( function() {
-			delete process.env[ 'LK_MISSING_FROM_CONFIG' ];
-			delete process.env[ 'lk_override-me' ];
+			delete process.env[ 'LK__MISSING__FROM__CONFIG' ];
+			delete process.env[ 'lk__override-me' ];
 		} );
 
 		describe( 'with no deploy-type environment var set', function() {
@@ -81,8 +81,8 @@ describe( 'when using deprecated API while providing environment prefix', functi
 		var cfg;
 
 		before( function() {
-			process.env[ 'lk_missing_from_config' ] = 'woo!';
-			process.env[ 'lk_override-me' ] = 'I HAZ OVERRIDE!';
+			process.env[ 'lk__missing__from__config' ] = 'woo!';
+			process.env[ 'lk__override-me' ] = 'I HAZ OVERRIDE!';
 			cfg = require( '../src/configya.js' )({
 				file: './spec/test.json',
 				prefix: 'lk'
@@ -90,8 +90,8 @@ describe( 'when using deprecated API while providing environment prefix', functi
 		} );
 
 		after( function() {
-			delete process.env[ 'lk_missing_from_config' ];
-			delete process.env[ 'lk_override-me' ];
+			delete process.env[ 'lk__missing__from__config' ];
+			delete process.env[ 'lk__override-me' ];
 		} );
 
 		describe( 'with no deploy-type environment var set', function() {
@@ -106,7 +106,7 @@ describe( 'when using deprecated API while providing environment prefix', functi
 			} );
 
 			it( 'environment key should return value', function() {
-				cfg.get( 'missing_from_config' )
+				cfg.get( 'missing__from__config' )
 					.should.equal( 'woo!' );
 			} );
 

--- a/spec/test.json
+++ b/spec/test.json
@@ -1,7 +1,8 @@
 {
 	"test-key": "hulloo",
 	"override-me": "you will see this only when you have deploy-type set to 'DEV'",
-	"NESTED_KEY": "a test of nested keys from files",
-	"INTEGRATION_AGENT_LOGLEVEL": "trace",
-	"INTEGRATION_AGENT_ID": "test123"
+	"NESTED_KEY": "a test of nested keys with camelCase syntax",
+	"NESTED__KEY": "a test of nested keys from files",
+	"INTEGRATION__AGENT__LOGLEVEL": "trace",
+	"INTEGRATION__AGENT__ID": "test123"
 }

--- a/src/configya.js
+++ b/src/configya.js
@@ -16,27 +16,38 @@ function deepMerge( target, source, overwrite ) {
 
 function ensurePath( target, val, paths ) {
 	var key = paths.shift();
-		k = key.toLowerCase();
 	if ( paths.length === 0 ) {
-		target[ k ] = val;
+		target[ key ] = val;
 	} else {
-		var child = target[ k ] || {};
-		target[ k ] = child;
+		var child = target[ key ] || {};
+		target[ key ] = child;
 		ensurePath( child, val, paths );
 	}
 }
 
+function camelCaseArray( arr ) {
+	return arr.map( function ( item, i ) {
+		if ( i > 0 ) {
+			return item[0].toUpperCase() + item.substr(1);
+		} else {
+			return item;
+		}
+	});
+}
+
 function parseIntoTarget( source, target, cache, prefix ) {
 	var preRgx = /^[_]*/;
-	var prefixRgx = new RegExp("^"+prefix+"_","i");
+	var prefixRgx = new RegExp("^"+prefix+"__","i");
 	var postRgx = /[_]*$/;
 
 	_.each( source, function( val, key ) {
 		key = key.replace(prefixRgx,'');
 
 		var k = key.toLowerCase();
-		var scrubbed = key.replace( preRgx, '' ).replace( postRgx, '' );
-		var paths = scrubbed.split( '_' );
+		var scrubbed = k.replace( preRgx, '' ).replace( postRgx, '' );
+		var paths = scrubbed.split( '__' ).map( function ( path ) {
+			return camelCaseArray( path.split( '_' ) ).join( '' );
+		});
 
 		if(prefixRgx.test(paths[0])){
 			paths.shift();


### PR DESCRIPTION
Hey @arobson @ifandelse @digitalBush 

This started as a look into supporting camelCase keys, but allowing them to be overridden by environment variables.

I looked first into other separators, but they will not work consistently since the base support seems to be for letters, numbers and underscores http://stackoverflow.com/a/2821183

After initial discussion with @arobson, I was going to look into conditionally supporting camel case only for keys with `__` in them. After also getting @rniemeyer and @ifandelse to weigh in, the idea was we should switch to only supporting `__` as the nested key separator, allowing `_` to separate words.

An added bonus is that the slightly odd signature of `__` helps you visually see what will become a new level vs just a multi-word key.

So `AUTH__USER_NAME=doug` and `ANALYTICS__HOST__APP_NAME=tracker` would become:

``` js
{
    auth: {
        userName: "doug"
    },
    analytics: {
        host: {
            appName: "tracker"
        }
    }
}
```

However, since this is a breaking change, and can be quite subjective – this PR is the start of the discussion. It could be modified to allow this to be configured or support both, but since we are primarily looking to use this at LeanKit, the default should be what our internal standard is (whatever that ends up being).
