### PR TITLE
Use _.filter instead of _.where

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "should": "~3.2.0-beta1"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^3.3.1"
   }
 }

--- a/src/configya.js
+++ b/src/configya.js
@@ -131,8 +131,8 @@ module.exports = function() {
 
 	if ( !newApi ){
 		options = {
-			file: _.where( args, _.isString )[0],
-			defaults: _.where( args, _.isObject )[0] || {}
+			file: _.filter( args, _.isString )[0],
+			defaults: _.filter( args, _.isObject )[0] || {}
 		}
 	}
 	return buildConfig(options);


### PR DESCRIPTION
We ran into issues a few times where configya picked up a lodash 3.x dependency and was erroring out like:

```
TypeError: Object 0 has no method 'replace'
    at /Users/RyanN/Code/leankit/configya/src/configya.js:58:13
    at baseEach (/Users/RyanN/Code/leankit/configya/node_modules/lodash/index.js:1853:13)
    at Function.forEach (/Users/RyanN/Code/leankit/configya/node_modules/lodash/index.js:5959:11)
    at parseIntoTarget (/Users/RyanN/Code/leankit/configya/src/configya.js:55:4)
    at buildConfig (/Users/RyanN/Code/leankit/configya/src/configya.js:113:2)
    at module.exports (/Users/RyanN/Code/leankit/configya/src/configya.js:138:9)
```

The issue was related to parsing the arguments when passing just the file name rather than an options object. It appears that in lodash 3.x, `_.where` no longer handles a predicate as a second argument. 

This PR changes `_.where` to `_.filter` and updates the version of lodash (not strictly necessary, but many of the other projects were recently updated to this version).  Existing tests cover this functionality.