### PR TITLE
Prevent array values from being partially merged with existing values

### DIFF
--- a/spec/argument-config.spec.js
+++ b/spec/argument-config.spec.js
@@ -41,6 +41,7 @@ describe( 'when configuring via arguments', function() {
 			process.env[ 'parsed_as_number_nodecimal' ] = '15142';
 			process.env[ 'parsed_as_number_decimal' ] = '15142.123';
 			process.env[ 'parsed_as_object' ] = '{"rich": "object"}';
+			process.env[ 'parsed_as_array' ] = '[1,2,3]';
 			process.env[ 'parsed_as_string' ] = '10p';
 			process.env[ 'override-me' ] = 'OVERRIDE!';
 			cfg = require( '../src/configya.js' )( './spec/test.json' );
@@ -55,6 +56,7 @@ describe( 'when configuring via arguments', function() {
 			delete process.env[ 'parsed_as_number_nodecimal' ];
 			delete process.env[ 'parsed_as_number_decimal' ];
 			delete process.env[ 'parsed_as_object' ];
+			delete process.env[ 'parsed_as_array' ];
 			delete process.env[ 'parsed_as_string' ];
 			delete process.env[ 'override-me' ];
 		} );
@@ -79,7 +81,7 @@ describe( 'when configuring via arguments', function() {
 					.should.equal( "prefix" );
 			} );
 
-			it( 'environment key parsing should handle booleans, numbers and strings', function() {
+			it( 'environment key parsing should handle booleans, numbers, strings, objects, and arrays', function() {
 				cfg.parsed.as.boolean
 					.should.equal( false );
 				cfg.parsed.as.number.nodecimal
@@ -88,6 +90,9 @@ describe( 'when configuring via arguments', function() {
 					.should.equal( 15142.123 );
 				cfg.parsed.as.object
 					.should.eql( { rich: "object" } );
+				cfg.parsed.as.array
+					.should.eql( [ 1, 2, 3 ] );
+
 				cfg.parsed.as.string
 					.should.equal( '10p' );
 			} );

--- a/spec/test.json
+++ b/spec/test.json
@@ -4,5 +4,10 @@
 	"NESTED_KEY": "a test of nested keys from files",
 	"INTEGRATION_AGENT_LOGLEVEL": "trace",
 	"INTEGRATION_AGENT_ID": "test123",
-	"NUMBER": "1234"
+	"NUMBER": "1234",
+	"parsed": {
+		"as": {
+			"array": [ 4, 5, 6, 7, 8 ]
+		}
+	}
 }

--- a/src/configya.js
+++ b/src/configya.js
@@ -5,7 +5,7 @@ var _ = require( 'lodash' );
 function deepMerge( target, source, overwrite ) {
 	_.each( source, function( val, key ) {
 		var original = target[ key ];
-		if( _.isObject( val ) ) {
+		if( _.isPlainObject( val ) ) {
 			if( original ) { deepMerge( original, val ); }
 			else { target[ key ] = val; }
 		} else {


### PR DESCRIPTION
Before this commit, if a config.json had a key with a value of [1,2,3] and an environment variable specified `"[4,5]"` the resulting value would be `[4,5,3]` instead of `[4,5]` as expected.